### PR TITLE
minor optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 hls-streamer
+
+# server logs
+logs/
+
+# segment results
+results/

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/sys v0.0.0-20191020212454-3e7259c5e7c2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4UpgHp07nNdFX7mqFfM=
+github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/hls/hls.go
+++ b/hls/hls.go
@@ -214,7 +214,7 @@ func (p *Hls) AddChunk(chunkData Chunk, saveChunklist bool) error {
 	return ret
 }
 
-// addChunk Adds a new chunk
+// String write info to chunklist.m3u8
 func (p *Hls) String() string {
 	var buffer bytes.Buffer
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,24 +1,35 @@
 package logger
 
 import (
+	"io"
 	"os"
 
+	"github.com/natefinch/lumberjack"
 	"github.com/sirupsen/logrus"
 )
 
+const timestampFormat = "2006-01-02 15:04:05.001 -0700 MST"
+
+// ConfigureLogger init log settings
 func ConfigureLogger(verbose bool) *logrus.Logger {
 	var log = logrus.New()
+	// default level is info
 	if verbose {
 		log.SetLevel(logrus.DebugLevel)
 	}
+	multiWriter := io.MultiWriter(os.Stderr, &lumberjack.Logger{
+		Filename:   "logs/server.log", // Filename is the file to write logs to.  Backup log files will be retained in the same directory.
+		MaxSize:    50,                // MaxSize is the maximum size in megabytes of the log file before it gets rotated
+		MaxBackups: 5,                 // MaxBackups is the maximum number of old log files to retain.
+		MaxAge:     30,                // MaxAge is the maximum number of days to retain old log files based on the timestamp encoded in their filename.
+	})
+	log.SetOutput(multiWriter)
 
-	formatter := new(logrus.JSONFormatter)
-	formatter.TimestampFormat = "01-01-2001 13:00:00"
-
-	log.SetFormatter(formatter)
-	log.SetFormatter(&logrus.JSONFormatter{})
-
-	log.SetOutput(os.Stdout)
+	dateFormatter := &logrus.JSONFormatter{
+		TimestampFormat: timestampFormat,
+	}
+	// output in JSON format
+	log.SetFormatter(dateFormatter)
 
 	return log
 }

--- a/manifestgenerator/manifestgenerator.go
+++ b/manifestgenerator/manifestgenerator.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/sirupsen/logrus"
 	"github.com/covrom/hls-streamer/hls"
 	"github.com/covrom/hls-streamer/mediachunk"
 	"github.com/covrom/hls-streamer/tspacket"
+	"github.com/sirupsen/logrus"
 )
 
 // Version Indicates the package version
@@ -583,7 +583,7 @@ func (mg *ManifestGenerator) nextChunk(currentPCRS float64, lastInitialPCRS floa
 	return
 }
 
-// Close Closes manigest processing saving last data and last chunk
+// Close Closes ManifestGenerator processing, saving last data and last chunk
 func (mg *ManifestGenerator) Close() {
 	//Generate last chunk
 	mg.nextChunk(mg.lastPCRS, mg.chunkStartTimeS, tspacket.MaxPCRSValue, true)


### PR DESCRIPTION
Hi covrom:

just some minor optimization

1. enable write log to file, and change log format for easy readable
 now it looks like this
```sh
{"level":"info","msg":"1.1.0","time":"2020-12-10 00:38:43.012 +0800 CST"}
{"level":"info","msg":"Started tssegmenter","time":"2020-12-10 00:38:43.012 +0800 CST"}
{"level":"info","msg":"HTTP server listening on :9099","time":"2020-12-10 00:38:43.012 +0800 CST"}
{"level":"info","msg":"TCP server listening localhost:9555","time":"2020-12-10 00:38:43.012 +0800 CST"}
{"level":"info","msg":"Wait for connecting source...","time":"2020-12-10 00:38:43.012 +0800 CST"}
{"level":"info","msg":"Wait for connecting source...","time":"2020-12-10 00:39:07.012 +0800 CST"}
{"level":"info","msg":"CHUNK! At PCRs: 7.1. ChunkDurS: 7.1","time":"2020-12-10 00:39:15.012 +0800 CST"}
{"level":"info","msg":"CHUNK! At PCRs: 13.533333333333333. ChunkDurS: 6.433333333333334","time":"2020-12-10 00:39:21.012 +0800 CST"}
{"level":"info","msg":"CHUNK! At PCRs: 19.8. ChunkDurS: 6.2666666666666675","time":"2020-12-10 00:39:28.012 +0800 CST"}
{"level":"info","msg":"CHUNK! At PCRs: 26.2. ChunkDurS: 6.399999999999999","time":"2020-12-10 00:39:34.012 +0800 CST"}
```

2.  Strings()  commnets was updated

3. manigest maybe a typo




